### PR TITLE
fix bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls && nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },
   "bin": {
-    "hpm": "index.js"
+    "hpm": "./index.js"
   },
   "files": [
     "hyperterm.js",


### PR DESCRIPTION
Not specifying a relative path doesn't work when I install with `npm install -g hpm`. Take a look at how everyone else does it, they use relative paths for bins.

https://github.com/facebookincubator/create-react-app/blob/master/package.json#L23-L25
https://github.com/mochajs/mocha/blob/master/package.json#L308-L311
https://github.com/webpack/webpack/blob/master/package.json#L74